### PR TITLE
Fix links to sections containing wikilinks

### DIFF
--- a/acnxpost.py
+++ b/acnxpost.py
@@ -64,7 +64,7 @@ def run(wiki):
                 if section.level == 2 and section.contents.strip().endswith("(UTC)") and section.contents.find(TACN) == -1:
                     if auth():
                         title = section.title.strip()
-                        linkstrippedtitle = re.sub('\[\[(?:.*\|)?(.*?)\]\]', '\1', title)
+                        linkstrippedtitle = re.sub('\[\[(?:.*?\|)?(.*?)\]\]', '\1', title)
                         logging.info('Found new section ' + ACN + '#' + title)
                         a = "\n: Discuss this at: '''[[" + TACN + "#" + linkstrippedtitle + "]]'''{{subst:hes}}\n\n"
                         announcement = section.contents.strip() + a


### PR DESCRIPTION
This should fix errors like what happened at https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Arbitration_Committee/Noticeboard&diff=prev&oldid=892477375, where the bot couldn't link to a section header with a link in it.

I've not tested this out on any testwiki, so I'd definitely suggest kicking the tires before merging.